### PR TITLE
Stop using `run` in test CA

### DIFF
--- a/tests/benchmark/test__ca.py
+++ b/tests/benchmark/test__ca.py
@@ -40,5 +40,6 @@ def test_raining_grid_simulation(
 
     @benchmark  # type: ignore[misc]
     def bench() -> None:
-        for _ in grid.run(limit=limit):
-            pass
+        for count, _ in enumerate(grid.frames):
+            if count >= limit:
+                break


### PR DESCRIPTION

- c674e5e | Stop using `run` in test CA
