### PR TITLE
Increment `frame_index` attribute correctly

### DIFF
--- a/led_matrix_controller/utils/cellular_automata/ca.py
+++ b/led_matrix_controller/utils/cellular_automata/ca.py
@@ -125,6 +125,8 @@ class Grid:
             for target_slice, mask, state in updates:
                 self._grid[target_slice][mask] = state.value
 
+            self.frame_index += 1
+
             yield self._grid
 
     @property


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved frame indexing for cellular automata animations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->