### PR TITLE
Add content ID to MQTT attrs

### DIFF
--- a/led_matrix_controller/content/base.py
+++ b/led_matrix_controller/content/base.py
@@ -298,11 +298,16 @@ class ContentBase(ABC, Generic[ContentType]):
                 return obj.__qualname__
 
         if is_dataclass(obj):
-            return {
+            dumped = {
                 key: getattr(obj, key)
                 for key, dc_field in obj.__dataclass_fields__.items()
                 if hasattr(obj, key) and dc_field.repr and not key.startswith("_")
             }
+
+            if hasattr(obj, "id"):
+                dumped.setdefault("id", obj.id)
+
+            return dumped
 
         if isinstance(obj, slice):
             return f"[{obj.start or ''}:{obj.stop or ''}:{obj.step or ''}]"


### PR DESCRIPTION


---



- e2790bc | Add content ID to MQTT attrs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved JSON serialization for dataclass instances to include the `id` attribute when present.
- **Bug Fixes**
	- Enhanced functionality of the `_json_encode` method for better handling of dataclass fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->