### PR TITLE
Update AudioProcess max magnitude to use rolling window/95P

### DIFF
--- a/led_matrix_controller/audio_processor.py
+++ b/led_matrix_controller/audio_processor.py
@@ -41,7 +41,7 @@ del _AV, _COMBO
 PYAUDIO = pyaudio.PyAudio()
 
 MAX_MAGNITUDE_TOPIC: Final = f"/{const.HOSTNAME}/audio-processor/max-magnitude"
-MAGNITUDE_HISTORY_SIZE: Final = 200
+MAGNITUDE_HISTORY_SIZE: Final = int(os.getenv("MAGNITUDE_HISTORY_SIZE", "200"))
 MAX_MAGNITUDE_RELATIVE_STEP: Final = float(
     os.getenv("MAX_MAGNITUDE_RELATIVE_STEP", "0.01"),
 )  # Max 1% change relative to current value

--- a/led_matrix_controller/audio_processor.py
+++ b/led_matrix_controller/audio_processor.py
@@ -194,10 +194,7 @@ class AudioProcessor:
         elif target_max_magnitude < prev:
             self.max_magnitude = max(target_max_magnitude, prev - actual_step_limit)
 
-        if (
-            prev != self.max_magnitude
-            and time.time() - self.last_mqtt_update > MAX_MAGNITUDE_UPDATE_FREQUENCY
-        ):
+        if prev != self.max_magnitude:
             LOGGER.info("Max magnitude: %.3f", self.max_magnitude)
 
             mqtt.CLIENT.publish(
@@ -219,7 +216,8 @@ class AudioProcessor:
 
         try:
             while self.active:
-                self.shm_array[:] = self.get_magnitudes()
+                if time.time() - self.last_mqtt_update > MAX_MAGNITUDE_UPDATE_FREQUENCY:
+                    self.shm_array[:] = self.get_magnitudes()
         except OSError as err:
             if "Unanticipated host error" in str(err):
                 LOGGER.warning(

--- a/led_matrix_controller/content/dynamic_content.py
+++ b/led_matrix_controller/content/dynamic_content.py
@@ -62,12 +62,13 @@ class DynamicContent(ContentBase[GridView], ABC):
         """
         try:
             return self.colormap[self.pixels]
-        except IndexError:
+        except IndexError as err:
             # This is usually due to an increase in magnitude, which then causes the pixels values
             # to exceed the colormap bounds
             LOGGER.warning(
-                "IndexError in get_content for %s. Pixel values exceed colormap bounds. Scaling down.",
+                "IndexError in get_content for %s. Pixel values exceed colormap bounds. Scaling down. %s",
                 self.__class__.__name__,
+                err,
             )
             colormap_size = self.colormap.shape[0]
 


### PR DESCRIPTION


---



- 231ae9f | Update max magnitude AP calc
- 8296af6 | Limit max change/frequency of changes
- d616f97 | Update freq
- b5ddd6f | log
- 66540eb | Try limiting all magnitude updates instead of just MQTT
- 647cb3d | same again
- 549a3c9 | Add `MAGNITUDE_HISTORY_SIZE` EV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced smoother and more stable audio normalization by gradually updating the normalization factor based on recent audio data.
  - Added configuration options for controlling smoothing behavior and update frequency via environment variables.

- **Bug Fixes**
  - Improved error logging for pixel value issues, providing more detailed information for diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->